### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/writeup_readme.yml
+++ b/.github/workflows/writeup_readme.yml
@@ -61,7 +61,7 @@ jobs:
         mv .README.temp README.md
         OUTPUT=0
         git diff --exit-code README.md || OUTPUT=$?
-        echo "::set-output name=OUTPUT::$OUTPUT"
+        echo "OUTPUT=$OUTPUT" >> $GITHUB_OUTPUT
     - name: Commit new README (if changed)
       if: steps.main.outputs.OUTPUT == 1
       run: |

--- a/.github/workflows/writeup_readme.yml
+++ b/.github/workflows/writeup_readme.yml
@@ -61,7 +61,7 @@ jobs:
         mv .README.temp README.md
         OUTPUT=0
         git diff --exit-code README.md || OUTPUT=$?
-        echo "OUTPUT=$OUTPUT" >> $GITHUB_OUTPUT
+        echo "OUTPUT=$OUTPUT" >> "$GITHUB_OUTPUT"
     - name: Commit new README (if changed)
       if: steps.main.outputs.OUTPUT == 1
       run: |


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


